### PR TITLE
Add codecov flags for ROS_DISTRO and ROS_version

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -24,4 +24,4 @@ docker cp $TRAVIS_BUILD_DIR "$ROS_DISTRO"-container:/"$ROS_DISTRO"_ws/src/
 docker exec "$ROS_DISTRO"-container /bin/bash \
   -c "sh /shared/$(basename ${SCRIPT_DIR})/"'ros"$ROS_VERSION"_build.sh' || travis_terminate 1;
 # upload coverage report to codecov
-bash <(curl -s https://codecov.io/bash) -Z
+bash <(curl -s https://codecov.io/bash) -Z -F "${ROS_DISTRO},ROS_${ROS_VERSION}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add codecov flags to get different coverage for each ROS distro and version

See successful usage on https://github.com/aws-robotics/utils-common/pull/22?src=pr&el=h1 where we have a table of coverage information per codecov flag

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
