### PR TITLE
Do not send codecov report if no test was run

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -24,4 +24,7 @@ docker cp $TRAVIS_BUILD_DIR "$ROS_DISTRO"-container:/"$ROS_DISTRO"_ws/src/
 docker exec "$ROS_DISTRO"-container /bin/bash \
   -c "sh /shared/$(basename ${SCRIPT_DIR})/"'ros"$ROS_VERSION"_build.sh' || travis_terminate 1;
 # upload coverage report to codecov
-bash <(curl -s https://codecov.io/bash) -Z -F "${ROS_DISTRO},ROS_${ROS_VERSION}"
+if [ -z "${NO_TEST}" ];
+then
+  bash <(curl -s https://codecov.io/bash) -Z -F "${ROS_DISTRO},ROS_${ROS_VERSION}"
+fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Do not send codecov report if no test was run. Otherwise the command will fail the build because there are no coverage file available, see https://travis-ci.org/aws-robotics/monitoringmessages-ros1/jobs/501809474. 
With this change the same project builds ok, see https://travis-ci.org/aws-robotics/monitoringmessages-ros1/builds/501815600

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
