### PR TITLE
Generate coverage information for Python on ROS 1

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -14,6 +14,7 @@ docker run -v "$PWD/shared:/shared" -e ROS_DISTRO="$ROS_DISTRO" \
   -e PACKAGE_NAME="$PACKAGE_NAME" \
   -e ROS_VERSION="$ROS_VERSION" \
   -e NO_TEST="$NO_TEST" \
+  -e PACKAGE_LANG="${PACKAGE_LANG:-cpp}" \
   --name "$ROS_DISTRO"-container \
   -dit ros:"$ROS_DISTRO"-ros-core /bin/bash
 # make a workspace in the docker container

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -6,24 +6,25 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # create a shared mount point to put coverage report
 mkdir shared/
 # move travis scripts to share mount so they can be executed within the docker container
-cp -r ${SCRIPT_DIR} shared/
+cp -r "${SCRIPT_DIR}" shared/
 # get a docker container from OSRF's docker hub
-docker pull ros:"$ROS_DISTRO"-ros-core
+docker pull "ros:${ROS_DISTRO}-ros-core"
 # run docker container
-docker run -v "$PWD/shared:/shared" -e ROS_DISTRO="$ROS_DISTRO" \
-  -e PACKAGE_NAME="$PACKAGE_NAME" \
-  -e ROS_VERSION="$ROS_VERSION" \
-  -e NO_TEST="$NO_TEST" \
+docker run -v "${PWD}/shared:/shared" \
+  -e ROS_DISTRO="${ROS_DISTRO}" \
+  -e PACKAGE_NAME="${PACKAGE_NAME}" \
+  -e ROS_VERSION="${ROS_VERSION}" \
+  -e NO_TEST="${NO_TEST}" \
   -e PACKAGE_LANG="${PACKAGE_LANG:-cpp}" \
-  --name "$ROS_DISTRO"-container \
-  -dit ros:"$ROS_DISTRO"-ros-core /bin/bash
+  --name "${ROS_DISTRO}-container" \
+  -dit "ros:${ROS_DISTRO}-ros-core" /bin/bash
 # make a workspace in the docker container
-docker exec "$ROS_DISTRO"-container /bin/bash -c 'mkdir -p /"$ROS_DISTRO"_ws/src'
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'mkdir -p "/${ROS_DISTRO}_ws/src"'
 # copy the code over to the docker container
-docker cp $TRAVIS_BUILD_DIR "$ROS_DISTRO"-container:/"$ROS_DISTRO"_ws/src/
+docker cp "${TRAVIS_BUILD_DIR}" "${ROS_DISTRO}-container":"/${ROS_DISTRO}_ws/src/"
 # execute build scripts and run test
-docker exec "$ROS_DISTRO"-container /bin/bash \
-  -c "sh /shared/$(basename ${SCRIPT_DIR})/"'ros"$ROS_VERSION"_build.sh' || travis_terminate 1;
+docker exec "${ROS_DISTRO}-container" /bin/bash \
+  -c "sh /shared/$(basename ${SCRIPT_DIR})/"'ros"${ROS_VERSION}"_build.sh' || travis_terminate 1;
 # upload coverage report to codecov
 if [ -z "${NO_TEST}" ];
 then

--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -11,15 +11,15 @@ apt-get install python-pip -y && pip install -U coverage
 export CATKIN_TEST_COVERAGE=1
 
 # use colcon as build tool to build the package, and optionally build tests
-. /opt/ros/$ROS_DISTRO/setup.sh
-cd /"$ROS_DISTRO"_ws/
-rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -r -y
+. "/opt/ros/${ROS_DISTRO}/setup.sh"
+cd "/${ROS_DISTRO}_ws/"
+rosdep install --from-paths src --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 if [ -z "${NO_TEST}" ];
 then
     if [ ! -z "${PACKAGE_NAME}" ];
     then
-      colcon build --packages-select $PACKAGE_NAME --cmake-target tests
+      colcon build --packages-select "${PACKAGE_NAME}" --cmake-target tests
     fi
 
     # run unit tests
@@ -33,11 +33,11 @@ then
             lcov --capture --directory . --output-file coverage.info
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             lcov --list coverage.info
-            cd /"$ROS_DISTRO"_ws/
+            cd "/${ROS_DISTRO}_ws/"
             mv coverage.info /shared
             ;;
         "python")
-            cd /"$ROS_DISTRO"_ws/build/${PACKAGE_NAME}
+            cd "/${ROS_DISTRO}_ws/build/${PACKAGE_NAME}"
             coverage xml
             cp coverage.xml /shared/coverage.info
             ;;

--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -5,6 +5,10 @@ set -e
 apt update && apt install -y lcov python3-pip libgtest-dev cmake && rosdep update
 cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
+# nosetests needs coverage for Python 2
+apt-get install python-pip -y && pip install -U coverage
+# enable Python coverage "https://github.com/ros/catkin/blob/kinetic-devel/cmake/test/nosetests.cmake#L59"
+export CATKIN_TEST_COVERAGE=1
 
 # use colcon as build tool to build the package, and optionally build tests
 . /opt/ros/$ROS_DISTRO/setup.sh
@@ -24,9 +28,18 @@ then
     colcon test-result --all
 
     # get unit test code coverage result
-    lcov --capture --directory . --output-file coverage.info
-    lcov --remove coverage.info '/usr/*' --output-file coverage.info
-    lcov --list coverage.info
-    cd /"$ROS_DISTRO"_ws/
-    mv coverage.info /shared
+    case ${PACKAGE_LANG} in 
+        "cpp") 
+            lcov --capture --directory . --output-file coverage.info
+            lcov --remove coverage.info '/usr/*' --output-file coverage.info
+            lcov --list coverage.info
+            cd /"$ROS_DISTRO"_ws/
+            mv coverage.info /shared
+            ;;
+        "python")
+            cd /"$ROS_DISTRO"_ws/build/${PACKAGE_NAME}
+            coverage xml
+            cp coverage.xml /shared/coverage.info
+            ;;
+    esac
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Generate coverage information for Python on ROS 1. The C++ or Python coverage is enabled by setting an env var `PACKAGE_LANG` on the travis configuration, with a default to `cpp` so no changes are required on the other packages. 

This has been tested on the builds for PRs https://github.com/aws-robotics/tts-ros1/pull/7 (Python) and https://github.com/aws-robotics/cloudwatch-common/pull/9 (C++) that run with success and leave a codecov coverage summary on the PR as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
