### PR TITLE
supports specifying workspaces to build for sample apps

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -21,6 +21,8 @@ else
   # SA_NAME is set - assume a Sample Application build
   BUILD_SCRIPT_NAME=ros"$ROS_VERSION"_sa_build.sh
 fi
+
+echo "using Build script, ${BUILD_SCRIPT_NAME}"
 DOCKER_BUILD_SCRIPT="/shared/$(basename ${SCRIPT_DIR})/${BUILD_SCRIPT_NAME}"
 # get a docker container from OSRF's docker hub
 docker pull "ros:${ROS_DISTRO}-ros-core"
@@ -34,6 +36,7 @@ docker run -v "${PWD}/shared:/shared" \
   -e PACKAGE_LANG="${PACKAGE_LANG:-cpp}" \
   -e GAZEBO_VERSION="${GAZEBO_VERSION:-7}" \
   -e DOCKER_BUILD_SCRIPT="${DOCKER_BUILD_SCRIPT}" \
+  -e WORKSPACES="${WORKSPACES}" \
   --name "${ROS_DISTRO}-container" \
   -dit "ros:${ROS_DISTRO}-ros-core" /bin/bash
 # make a workspace in the docker container

--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -11,7 +11,10 @@ pip3 install colcon-bundle colcon-ros-bundle
 
 BUILD_DIR_NAME=`basename $TRAVIS_BUILD_DIR`
 
-IFS=','
+if [ -z "$WORKSPACES" ]; then
+  WORKSPACES="robot_ws simulation_ws"
+fi
+
 for WS in $WORKSPACES
 do
   # use colcon as build tool to build the workspace if it exists
@@ -25,7 +28,11 @@ do
       bash "${WS_BUILD_SCRIPT}"
       mv ./bundle/output.tar.gz /shared/"${WS}".tar.gz
     else
-      echo "Unable to find build script ${WS_BUILD_SCRIPT}, skipping build"
+      echo "Unable to find build script ${WS_BUILD_SCRIPT}, build failed"
+      exit 1
     fi
+  else
+    echo "Unable to find workspace ${WS_DIR}, build failed"
+    exit 1
   fi
 done

--- a/ws_builds/robot_ws.sh
+++ b/ws_builds/robot_ws.sh
@@ -1,4 +1,5 @@
+#!/bin/bash
 rosws update
 rosdep install --from-paths src --ignore-src -r -y
 colcon build --build-base build --install-base install
-colcon bundle --build-base build --install-base install --bundle-base bundle
+colcon bundle --bundle-version 1 --build-base build --install-base install --bundle-base bundle

--- a/ws_builds/robot_ws.sh
+++ b/ws_builds/robot_ws.sh
@@ -1,0 +1,4 @@
+rosws update
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --build-base build --install-base install
+colcon bundle --build-base build --install-base install --bundle-base bundle

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+rosws update
+rosdep install --from-paths src --ignore-src -r -y
+GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${GAZEBO_VERSION}/post_rosdep_install.sh"
+if [ -f ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT} ]; then bash ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT}; fi
+colcon build --build-base build --install-base install
+colcon bundle --build-base build --install-base install --bundle-base bundle

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -4,4 +4,4 @@ rosdep install --from-paths src --ignore-src -r -y
 GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${GAZEBO_VERSION}/post_rosdep_install.sh"
 if [ -f ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT} ]; then bash ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT}; fi
 colcon build --build-base build --install-base install
-colcon bundle --build-base build --install-base install --bundle-base bundle
+colcon bundle --bundle-version 1 --build-base build --install-base install --bundle-base bundle


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Allows for specifying workspaces to be built with their own build scripts for sample applications. This change is necessary to support DeepRacer and ObjectTracker

Tested (without deploy step) against DeepRacer, HelloWorld, and CloudWatchLogs CE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
