### PR TITLE
Install boto3

### DIFF
--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 # install dependencies
 apt update && apt install -y python3-pip python3-apt dpkg ros-$ROS_DISTRO-ros-base && rosdep update
 apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
-pip3 install colcon-bundle colcon-ros-bundle
+pip3 install colcon-bundle colcon-ros-bundle boto3
 . /opt/ros/$ROS_DISTRO/setup.sh
 
 BUILD_DIR_NAME=`basename $TRAVIS_BUILD_DIR`


### PR DESCRIPTION
- boto3 is required for the Object Tracker sample application download_model.py script.

## Testing

Not yet tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
