### PR TITLE
parametrize workspace folders to be zipped as artifacts

### DIFF
--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -27,7 +27,7 @@ do
 done
 
 # Create archive of all sources files
-SOURCES_INCLUDES="robot_ws simulation_ws LICENSE* NOTICE* README* roboMakerSettings.json"
+SOURCES_INCLUDES="${WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
 cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
 /usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
 tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES


### PR DESCRIPTION
*Issue #, if available:*

SA deep racer's travis process failed due to hard-coded `robot_ws` as a zipped source in travis build script. This PR will resolve the build failure.

Tested: https://travis-ci.org/aws-robotics/aws-robomaker-sample-application-deepracer/builds/520538203

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
