### PR TITLE
Fix Gazebo9 Builds

### DIFF
--- a/gazebo/9/post_rosdep_install.sh
+++ b/gazebo/9/post_rosdep_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install Gazebo 9, and remove gazebo 7
-set -e
+set -ex
 
 echo "Setting up Gazebo 9"
 

--- a/gazebo/9/post_rosdep_install.sh
+++ b/gazebo/9/post_rosdep_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install Gazebo 9, and remove gazebo 7
-set -ex
+set -e
 
 echo "Setting up Gazebo 9"
 

--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -e
+set -ex
 
-SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
+export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 
 # install dependencies
 apt update && apt install -y zip python3-pip python3-apt dpkg ros-$ROS_DISTRO-ros-base && rosdep update

--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+set -ex
 rosws update
 GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${GAZEBO_VERSION}/post_rosdep_install.sh"
 if [ -f ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT} ]; then bash ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT}; fi

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -ex
 rosws update
-rosdep install --from-paths src --ignore-src -r -y
 GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${GAZEBO_VERSION}/post_rosdep_install.sh"
 if [ -f ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT} ]; then bash ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT}; fi
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
 colcon build --build-base build --install-base install
 colcon bundle --build-base build --install-base install --bundle-base bundle

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 rosws update
 rosdep install --from-paths src --ignore-src -r -y
 GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${GAZEBO_VERSION}/post_rosdep_install.sh"

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -ex
-set -ex
+#!/bin/bash
 rosws update
 GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${GAZEBO_VERSION}/post_rosdep_install.sh"
 if [ -f ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT} ]; then bash ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT}; fi


### PR DESCRIPTION
- Export SCRIPT_DIR so that the simulation_ws.sh file can use it for finding the Gazebo9 build dir
- Run `rosdep update` and `rosdep install` after configuring apt to use gazebo9 repositories so that it installs gazebo9 dependencies for gazebo9 builds. 

Building person detection with these new changes to confirm they work here: https://travis-ci.org/aws-robotics/aws-robomaker-sample-application-persondetection/builds/521426733

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
