### PR TITLE
add --verbose to "colcon test-result"

### DIFF
--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -44,7 +44,7 @@ then
     fi
 
     colcon test
-    colcon test-result --all
+    colcon test-result --all --verbose
 
     # get unit test code coverage result
     case ${PACKAGE_LANG} in 


### PR DESCRIPTION
*Issue #, if available:*
This is for assisting the debug of https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/18, but this is also a general enhancement of the build infrastructure.

*Description of changes:*
Increase verbosity of test results reported by colcon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
