### PR TITLE
Add timestamp to version.json file in AppManifest repo

### DIFF
--- a/codepipeline_deploy.sh
+++ b/codepipeline_deploy.sh
@@ -25,4 +25,5 @@ if [ -z "$SA_VERSION" ]; then
     exit 1
 fi
 
-aws codecommit put-file --repository-name "$APP_MANIFEST_REPO" --branch-name mainline --file-content "{\"application_version\": \"$SA_VERSION\"}" --file-path "/version.json" --commit-message "Updating to version $SA_VERSION. Commit for this version bump: $TRAVIS_COMMIT" --name "$GH_USER_NAME" --email "$GH_USER_EMAIL" $PARENT_COMMIT_FLAG
+TIMESTAMP=`date +%s`
+aws codecommit put-file --repository-name "$APP_MANIFEST_REPO" --branch-name mainline --file-content "{\"application_version\": \"$SA_VERSION\",\"timestamp\":\"$TIMESTAMP\"}" --file-path "/version.json" --commit-message "Updating to version $SA_VERSION. Commit for this version bump: $TRAVIS_COMMIT" --name "$GH_USER_NAME" --email "$GH_USER_EMAIL" $PARENT_COMMIT_FLAG


### PR DESCRIPTION
- If CodeCommit put-file is called with the exact same file contents it
throws an error. This means that Travis rebuilds always fail because
they are building and committing the same version. Adding a timestamp
to ensure rebuilds work correctly.

Issue: P22718112

Tested by setting these environment variables manually and running the script and it could commit the same version twice. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
