### PR TITLE
Always install colcon bundle from source

### DIFF
--- a/gazebo/9/post_rosdep_install.sh
+++ b/gazebo/9/post_rosdep_install.sh
@@ -10,12 +10,6 @@ echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -c
 wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 apt-get update
 
-COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
-rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
-git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
-pip3 install --upgrade pip
-pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
-
 G9_APT_FILE="/etc/ros/rosdep/sources.list.d/00-gazebo9.list"
 rm -f "${G9_APT_FILE}"
 touch "${G9_APT_FILE}"

--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -10,6 +10,13 @@ sh -c 'echo "deb  http://13.52.195.14/ubuntu/main $(lsb_release -sc) main" > /et
 apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 apt-get update && apt-get install --no-install-recommends -y python-rosdep python-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
 pip3 install colcon-bundle colcon-ros-bundle
+# Get latest colcon bundle
+COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
+rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
+git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
+pip3 install --upgrade pip
+pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
+
 # Remove the old rosdep sources.list
 rm -rf /etc/ros/rosdep/sources.list.d/*
 rosdep init && rosdep update

--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -10,10 +10,19 @@ sh -c 'echo "deb  http://13.52.195.14/ubuntu/main $(lsb_release -sc) main" > /et
 apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 apt-get update && apt-get install --no-install-recommends -y python-rosdep python-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
 pip3 install colcon-bundle colcon-ros-bundle
+
 # Get latest colcon bundle
 COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
 rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
 git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
+
+# Switch to commit "Support Melodic, fix aptitude trusted key config"
+#  https://github.com/colcon/colcon-bundle/commit/d5ea60e1a9adb34c5ba96e0fbd32fcd188cde15a
+WORKING_DIRECTORY=${PWD}
+cd ${COLCON_BUNDLE_INSTALL_PATH}
+git checkout d5ea60e1a9adb34c5ba96e0fbd32fcd188cde15a
+cd ${WORKING_DIRECTORY}
+
 pip3 install --upgrade pip
 pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
 


### PR DESCRIPTION
It may take time to release new versions of colcon bundle to pip. This makes from-source installation the default (and unblocks Melodic CI for SAs).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
