### PR TITLE
Bash should allow failures on 'codecommit get-branch' in codepipeline_deploy.sh

### DIFF
--- a/codepipeline_deploy.sh
+++ b/codepipeline_deploy.sh
@@ -8,8 +8,11 @@ if [ ! -z "${TRAVIS_TAG}" ]; then
 fi
 
 # Get the HEAD commit ID for version.json in master branch if exists
+set +e # May fail
 BRANCH_INFO=`aws codecommit get-branch --repository-name $APP_MANIFEST_REPO --branch-name mainline`
-if [ $? -ne 0 ]; then
+BRANCH_INFO_STATUS=$?
+set -e
+if [ $BRANCH_INFO_STATUS -ne 0 ]; then
     echo "Could not find mainline branch for repository $APP_MANIFEST_REPO. Creating first commit."
 else
     export BRANCH_COMMIT_ID=`echo $BRANCH_INFO | jq -r '.branch.commitId'`


### PR DESCRIPTION
Bug that causes build (deployment) failures for the case where the branch does not exist (https://travis-ci.org/aws-robotics/aws-robomaker-sample-application-helloworld/jobs/547894196)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
