### PR TITLE
Update travis-scripts

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -29,7 +29,7 @@ docker pull "ros:${ROS_DISTRO}-ros-core"
 # run docker container
 docker run -v "${PWD}/shared:/shared" \
   -e ROS_DISTRO="${ROS_DISTRO}" \
-  -e PACKAGE_NAME="${PACKAGE_NAME}" \
+  -e PACKAGE_NAMES="${PACKAGE_NAMES}" \
   -e ROS_VERSION="${ROS_VERSION}" \
   -e NO_TEST="${NO_TEST}" \
   -e TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR}" \

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -xe
 
 if [ ! -z "${TRAVIS_TAG}" ]; then
     # Do not run for builds triggered by tagging.
@@ -23,7 +23,7 @@ else
 fi
 
 echo "using Build script, ${BUILD_SCRIPT_NAME}"
-DOCKER_BUILD_SCRIPT="/shared/$(basename ${SCRIPT_DIR})/${BUILD_SCRIPT_NAME}"
+DOCKER_BUILD_SCRIPT="/shared/$(basename -- ${SCRIPT_DIR})/${BUILD_SCRIPT_NAME}"
 # get a docker container from OSRF's docker hub
 docker pull "ros:${ROS_DISTRO}-ros-core"
 # run docker container
@@ -33,7 +33,7 @@ docker run -v "${PWD}/shared:/shared" \
   -e ROS_VERSION="${ROS_VERSION}" \
   -e NO_TEST="${NO_TEST}" \
   -e TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR}" \
-  -e $TRAVIS_BRANCH="${TRAVIS_BRANCH}" \
+  -e TRAVIS_BRANCH="${TRAVIS_BRANCH}" \
   -e PACKAGE_LANG="${PACKAGE_LANG:-cpp}" \
   -e GAZEBO_VERSION="${GAZEBO_VERSION:-7}" \
   -e DOCKER_BUILD_SCRIPT="${DOCKER_BUILD_SCRIPT}" \

--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -xe
 
 # install dependencies
 apt update && apt install -y lcov python3-pip python-rosinstall libgtest-dev cmake && rosdep update
@@ -11,9 +11,10 @@ apt-get install python-pip -y && pip install -U coverage
 export CATKIN_TEST_COVERAGE=1
 
 . "/opt/ros/${ROS_DISTRO}/setup.sh"
-REPO_NAME=`echo $TRAVIS_BUILD_DIR | cut -c 33-`
-cd "/${ROS_DISTRO}_ws/"
+REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})
+echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"
 
+cd "/${ROS_DISTRO}_ws/"
 # use colcon as build tool to build the package, and optionally build tests
 if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
     mkdir dep

--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -3,14 +3,12 @@ set -xe
 
 # install dependencies
 apt update && apt install -y lcov python3-pip python-rosinstall libgtest-dev cmake && rosdep update
-cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
 # nosetests needs coverage for Python 2
 apt-get install python-pip -y && pip install -U coverage
 # enable Python coverage "https://github.com/ros/catkin/blob/kinetic-devel/cmake/test/nosetests.cmake#L59"
 export CATKIN_TEST_COVERAGE=1
 
-. "/opt/ros/${ROS_DISTRO}/setup.sh"
 REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})
 echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"
 
@@ -26,6 +24,8 @@ if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.ma
 else
     rosdep install --from-paths src --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
 fi
+
+. "/opt/ros/${ROS_DISTRO}/setup.sh"
 
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 

--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -15,8 +15,7 @@ REPO_NAME=`echo $TRAVIS_BUILD_DIR | cut -c 33-`
 cd "/${ROS_DISTRO}_ws/"
 
 # use colcon as build tool to build the package, and optionally build tests
-if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ];
-then
+if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
     mkdir dep
     cd "/${ROS_DISTRO}_ws/dep"
     ln -s "../src/${REPO_NAME}/.rosinstall.master" .rosinstall
@@ -28,18 +27,16 @@ else
 fi
 
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
-if [ -z "${NO_TEST}" ];
-then
-    if [ ! -z "${PACKAGE_NAME}" ];
-    then
-      colcon build --packages-select "${PACKAGE_NAME}" --cmake-target tests
+
+if [ -z "${NO_TEST}" ]; then
+    if [ ! -z "${PACKAGE_NAMES}" ]; then
+        colcon build --packages-select ${PACKAGE_NAMES} --cmake-target tests
     fi
 
     # run unit tests
     . ./install/setup.sh
 
-    if [ "${TRAVIS_BRANCH}" == "master" ];
-    then
+    if [ "${TRAVIS_BRANCH}" == "master" ]; then
         touch dep/COLCON_IGNORE
     fi
 
@@ -56,7 +53,8 @@ then
             mv coverage.info /shared
             ;;
         "python")
-            cd "/${ROS_DISTRO}_ws/build/${PACKAGE_NAME}"
+            # this doesn't actually support multiple packages
+            cd "/${ROS_DISTRO}_ws/build/${PACKAGE_NAMES}"
             coverage xml
             cp coverage.xml /shared/coverage.info
             ;;

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -9,15 +9,15 @@ cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
 
 # use colcon as build tool to build the package, and optionally build tests
-. /opt/ros/$ROS_DISTRO/setup.sh
-cd /"$ROS_DISTRO"_ws/
-rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -r -y
+. "/opt/ros/${ROS_DISTRO}/setup.sh"
+cd "/${ROS_DISTRO}_ws/"
+rosdep install --from-paths src --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
+
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
-if [ -z "${NO_TEST}" ];
-then
-    if [ ! -z "${PACKAGE_NAME}" ] && [ "$ROS_VERSION" == "1" ];
-    then
-      colcon build --packages-select $PACKAGE_NAME --cmake-target tests
+
+if [ -z "${NO_TEST}" ]; then
+    if [ ! -z "${PACKAGE_NAMES}" ] && [ "${ROS_VERSION}" == "1" ]; then
+        colcon build --packages-select ${PACKAGE_NAMES} --cmake-target tests
     fi
 
     # run unit tests
@@ -29,6 +29,6 @@ then
     lcov --capture --directory . --output-file coverage.info
     lcov --remove coverage.info '/usr/*' --output-file coverage.info
     lcov --list coverage.info
-    cd /"$ROS_DISTRO"_ws/
+    cd "/${ROS_DISTRO}_ws/"
     mv coverage.info /shared
 fi


### PR DESCRIPTION
*Description of changes:*

Major changes include the following:
- Support building `make test` target for multiple packages per repo
- Stop building `gtest` manually, as with the incoming `CMakeLists.txt` update will depend on `catkin` to build it (and building `gtest` manually is incompatible with this flow)
- Fix bug where `rosws update` would never be called
- Turn on `bash` debugging

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.