### PR TITLE
ROS2 CI adjustments

### DIFF
--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -4,9 +4,8 @@ set -xe
 # install dependencies
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
-apt update && apt install -y python3 python3-pip libgtest-dev lcov cmake && rosdep update
-cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
-apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
+apt update && apt install -y python3 python3-pip lcov cmake && rosdep update
+apt update && apt install -y python3-rosinstall python3-colcon-common-extensions && pip3 install -U setuptools
 
 REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})
 echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -27,12 +27,11 @@ fi
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 
 if [ -z "${NO_TEST}" ]; then
-    if [ ! -z "${PACKAGE_NAMES}" ] && [ "${ROS_VERSION}" == "1" ]; then
-        colcon build --packages-select ${PACKAGE_NAMES} --cmake-target tests
-    fi
-
     # run unit tests
     . ./install/setup.sh
+    if [ "${TRAVIS_BRANCH}" == "master" ] && [ -d "./dep" ]; then
+        touch dep/COLCON_IGNORE
+    fi
     colcon test
     colcon test-result --all --verbose
 

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -8,6 +8,9 @@ apt update && apt install -y python3 python3-pip libgtest-dev lcov cmake && rosd
 cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
 
+REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})
+echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"
+
 # use colcon as build tool to build the package, and optionally build tests
 . "/opt/ros/${ROS_DISTRO}/setup.sh"
 cd "/${ROS_DISTRO}_ws/"

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -11,7 +11,16 @@ apt update && apt install -y python3-colcon-common-extensions && pip3 install -U
 # use colcon as build tool to build the package, and optionally build tests
 . "/opt/ros/${ROS_DISTRO}/setup.sh"
 cd "/${ROS_DISTRO}_ws/"
-rosdep install --from-paths src --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
+if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
+    mkdir dep
+    cd "/${ROS_DISTRO}_ws/dep"
+    ln -s "../src/${REPO_NAME}/.rosinstall.master" .rosinstall
+    rosws update
+    cd "/${ROS_DISTRO}_ws/"
+    rosdep install --from-paths src dep --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
+else
+    rosdep install --from-paths src --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
+fi
 
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -34,7 +34,7 @@ if [ -z "${NO_TEST}" ]; then
     # run unit tests
     . ./install/setup.sh
     colcon test
-    colcon test-result --all
+    colcon test-result --all --verbose
 
     # get unit test code coverage result
     lcov --capture --directory . --output-file coverage.info

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -xe
 
 # install dependencies
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116


### PR DESCRIPTION
* Remove gtest preinstallation (ament takes care of that)
* Setup master build like in ros1

Build passes with this change: https://travis-ci.com/AAlon/utils-ros2-copy/builds/119010363

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
