### PR TITLE
ROS2 builds should always use .rosinstall

### DIFF
--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -13,7 +13,7 @@ echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"
 # use colcon as build tool to build the package, and optionally build tests
 . "/opt/ros/${ROS_DISTRO}/setup.sh"
 cd "/${ROS_DISTRO}_ws/"
-if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
+if [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
     mkdir dep
     cd "/${ROS_DISTRO}_ws/dep"
     ln -s "../src/${REPO_NAME}/.rosinstall.master" .rosinstall


### PR DESCRIPTION
Since we haven't released our packages to apt yet, we should always run `rosws update` if the .rosinstall file exists, regardless of the branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
