### PR TITLE
Add initial support for ROS2 SA build

### DIFF
--- a/gazebo/dashing-gazebo9/post_rosdep_install.sh
+++ b/gazebo/dashing-gazebo9/post_rosdep_install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Only set up Gazebo's repository
+set -e
+
+echo "Setting up Gazebo repository"
+
+apt-get install wget -y
+echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+apt-get update

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -xe
+
+export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
+
+# install dependencies
+apt-get update && apt-get install -q -y dirmngr curl gnupg2 lsb-release zip python3-pip python3-apt dpkg
+pip3 install -U setuptools
+
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+apt-get update && apt-get install --no-install-recommends -y python-rosdep python3-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
+pip3 install colcon-bundle colcon-ros-bundle
+
+# Get latest colcon bundle
+COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
+rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
+git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
+
+pip3 install --upgrade pip
+pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
+
+# Remove the old rosdep sources.list
+rm -rf /etc/ros/rosdep/sources.list.d/*
+rosdep init && rosdep update
+
+. /opt/ros/$ROS_DISTRO/setup.sh
+
+BUILD_DIR_NAME=`basename $TRAVIS_BUILD_DIR`
+
+if [ -z "$WORKSPACES" ]; then
+  WORKSPACES="robot_ws simulation_ws"
+fi
+
+# Run ROSWS update in each workspace before creating archive
+for WS in $WORKSPACES
+do
+  WS_DIR="/${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/${WS}"
+  echo "looking for ${WS}, $WS_DIR"
+  if [ -d "${WS_DIR}" ]; then
+    echo "WS ${WS_DIR} found, running rosws update"
+    rosws update -t "${WS_DIR}"
+  fi
+done
+
+# Create archive of all sources files
+SOURCES_INCLUDES="${WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
+cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
+/usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
+tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES
+
+for WS in $WORKSPACES
+do
+  # use colcon as build tool to build the workspace if it exists
+  WS_DIR="/${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/${WS}"
+  WS_BUILD_SCRIPT="/shared/$(basename ${SCRIPT_DIR})/ws_builds/${WS}.sh"
+  if [ -f "${WS_BUILD_SCRIPT}" ]; then
+    cd "${WS_DIR}"
+    "${WS_BUILD_SCRIPT}"
+    mv ./bundle/output.tar /shared/"${WS}".tar
+  else
+    echo "Unable to find build script ${WS_BUILD_SCRIPT}, build failed"
+    exit 1
+  fi
+done

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -18,7 +18,7 @@ rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
 git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
 
 pip3 install --upgrade pip
-pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
+pip3 install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
 
 # Remove the old rosdep sources.list
 rm -rf /etc/ros/rosdep/sources.list.d/*
@@ -56,7 +56,7 @@ do
   WS_BUILD_SCRIPT="/shared/$(basename ${SCRIPT_DIR})/ws_builds/${WS}.sh"
   if [ -f "${WS_BUILD_SCRIPT}" ]; then
     cd "${WS_DIR}"
-    "${WS_BUILD_SCRIPT}"
+    bash "${WS_BUILD_SCRIPT}"
     mv ./bundle/output.tar /shared/"${WS}".tar
   else
     echo "Unable to find build script ${WS_BUILD_SCRIPT}, build failed"

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -7,7 +7,7 @@ export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 apt-get update && apt-get install -q -y dirmngr curl gnupg2 lsb-release zip python3-pip python3-apt dpkg
 pip3 install -U setuptools
 
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
 apt-get update && apt-get install --no-install-recommends -y python-rosdep python3-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
 pip3 install colcon-bundle colcon-ros-bundle

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -18,7 +18,7 @@ rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
 git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
 
 pip3 install --upgrade pip
-pip3 install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
+pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
 
 # Remove the old rosdep sources.list
 rm -rf /etc/ros/rosdep/sources.list.d/*

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -15,10 +15,14 @@ pip3 install colcon-bundle colcon-ros-bundle
 # Get latest colcon bundle
 COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
 rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
-git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
+COLCON_ROS_BUNDLE_INSTALL_PATH="${HOME}/colcon-ros-bundle"
+rm -rf "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
+git clone -b ros2-support https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
+git clone -b ros2-support https://github.com/colcon/colcon-ros-bundle "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
 
 pip3 install --upgrade pip
 pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
+pip install -U --editable "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
 
 # Remove the old rosdep sources.list
 rm -rf /etc/ros/rosdep/sources.list.d/*

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -9,7 +9,7 @@ pip3 install -U setuptools
 
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
-apt-get update && apt-get install --no-install-recommends -y python-rosdep python3-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
+apt-get update && apt-get install --no-install-recommends -y python3-rosdep python3-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
 pip3 install colcon-bundle colcon-ros-bundle
 
 # Get latest colcon bundle

--- a/ws_builds/robot_ws.sh
+++ b/ws_builds/robot_ws.sh
@@ -2,6 +2,11 @@
 set -xe
 
 rosws update
+GAZEBO_POST_ROSDEP_INSTALL_SCRIPT="${SCRIPT_DIR}/gazebo/${ROS_DISTRO}-gazebo${GAZEBO_VERSION}/post_rosdep_install.sh"
+if [ -f ${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT} ]; then
+    "${GAZEBO_POST_ROSDEP_INSTALL_SCRIPT}"
+fi
+
 rosdep install --from-paths src --ignore-src -r -y
 
 colcon build --build-base build --install-base install


### PR DESCRIPTION
Changes that apply to ROS2 only:
* Added ros2_sa_build.sh
* Added a post-rosdep step for dashing to add the Gazebo apt key

Version-agnostic changes:
* Run the post-rosdep step for `robot_ws` too. Without this we basically restrict the `robot_ws` to not contain any packages that require additional steps / special handling (e.g. Gazebo), which is an arbitrary and unneeded restriction. It used to be OK because the `robot_ws`s really didn't have any gazebo packages. It breaks now because we have to pull in the entire `turtlebot3` repo for ROS2 and it contains gazebo-related packages.

Example builds using this branch:
* ROS1: https://travis-ci.org/AAlon/aws-robomaker-sample-application-helloworld/builds/566772961
* ROS2: https://travis-ci.org/AAlon/aws-robomaker-sample-application-helloworld/builds/566762653

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
