### PR TITLE
Unified codecov which excludes test code

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -17,6 +17,10 @@ if [ -z "${SA_NAME}" ];
 then
   # SA_NAME not set - assume a Cloud Extension build
   BUILD_SCRIPT_NAME=ros"$ROS_VERSION"_build.sh
+  # Copy codecov configuration if one doesn't already exist
+  if [ ! -f "${TRAVIS_BUILD_DIR}/.codecov.yml" ]; then 
+    cp "${SCRIPT_DIR}/ce_codecov.yml" "${TRAVIS_BUILD_DIR}/.codecov.yml"
+  fi
 else
   # SA_NAME is set - assume a Sample Application build
   BUILD_SCRIPT_NAME=ros"$ROS_VERSION"_sa_build.sh

--- a/ce_codecov.yml
+++ b/ce_codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  ignore:
+    - "**/test/*"
+  status:
+    # doc: https://docs.codecov.io/docs/commit-status
+    project:
+      default:
+        # will use the coverage from the base commit (pull request base or parent commit) coverage to compare against.
+        target: auto
+        threshold: null
+        # will use the pull request base if the commit is on a pull request. If not, the parent commit will be used.
+        base: auto


### PR DESCRIPTION
* Each CE repo has its own codecov file but they're all the same so we should have it be part of travis-scripts. 
* The codecov file added here contains a fix to exclude test files from coverage (right now we're overestimating our coverage).

Successful build & report generation: removed `.codecov.yml` from my fork of utils-common and verified the report still got generated successfully: https://codecov.io/gh/AAlon/utils-common/commit/0654f67e0a95bc8af4e9a28caf04db7de32495d1

The next step would be to remove `.codecov.yml` files from all CEs repos.

Related: https://community.codecov.io/t/100-coverage-with-empty-tests/422

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
