### PR TITLE
Ignore exit code of colcon-test 

### DIFF
--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -40,10 +40,12 @@ if [ -z "${NO_TEST}" ]; then
     if [ "${TRAVIS_BRANCH}" == "master" ] && [ -d "./dep" ]; then
         touch dep/COLCON_IGNORE
     fi
-
+    
+    set +e
     colcon test
+    set -e
     colcon test-result --all --verbose
-
+    
     # get unit test code coverage result
     case ${PACKAGE_LANG} in
         "cpp")

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -33,7 +33,10 @@ if [ -z "${NO_TEST}" ]; then
     if [ "${TRAVIS_BRANCH}" == "master" ] && [ -d "./dep" ]; then
         touch dep/COLCON_IGNORE
     fi
+    
+    set +e
     colcon test
+    set -e
     colcon test-result --all --verbose
 
     # get unit test code coverage result


### PR DESCRIPTION
This should make it possible to know what happened in builds like https://travis-ci.org/aws-robotics/tts-ros2/builds/578541063.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
