### PR TITLE
[ros1_build.sh] Support NO_TEST option and remove argument --cmake-target tests

### DIFF
--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -27,12 +27,8 @@ fi
 
 . "/opt/ros/${ROS_DISTRO}/setup.sh"
 
-colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
-
 if [ -z "${NO_TEST}" ]; then
-    if [ ! -z "${PACKAGE_NAMES}" ]; then
-        colcon build --packages-select ${PACKAGE_NAMES} --cmake-target tests
-    fi
+    colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 
     # run unit tests
     . ./install/setup.sh
@@ -62,4 +58,6 @@ if [ -z "${NO_TEST}" ]; then
             cp coverage.xml /shared/coverage.info
             ;;
     esac
+else
+    colcon build --catkin-skip-building-tests --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 fi


### PR DESCRIPTION
By default the 'tests' target of 'catkin' packages is invoked (as of colcon-ros 0.36).
If we specify it explicitly it will not enable CATKIN_ENABLE_TESTING which will cause the build to fail if the test target is guarded with that condition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
