### PR TITLE
Use latest released colcon-bundle

### DIFF
--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -11,21 +11,6 @@ apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BAD
 apt-get update && apt-get install --no-install-recommends -y python-rosdep python-rosinstall python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
 pip3 install colcon-bundle colcon-ros-bundle
 
-# Get latest colcon bundle
-COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
-rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
-git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
-
-# Switch to commit "Support Melodic, fix aptitude trusted key config"
-#  https://github.com/colcon/colcon-bundle/commit/d5ea60e1a9adb34c5ba96e0fbd32fcd188cde15a
-WORKING_DIRECTORY=${PWD}
-cd ${COLCON_BUNDLE_INSTALL_PATH}
-git checkout d5ea60e1a9adb34c5ba96e0fbd32fcd188cde15a
-cd ${WORKING_DIRECTORY}
-
-pip3 install --upgrade pip
-pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
-
 # Remove the old rosdep sources.list
 rm -rf /etc/ros/rosdep/sources.list.d/*
 rosdep init && rosdep update


### PR DESCRIPTION
Should fix CI errors like in https://travis-ci.org/aws-robotics/aws-robomaker-sample-application-cloudwatch/jobs/584286765
```
12.190s] ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_bundle.task.bundle.ros.ament': (colcon-bundle 0.0.13 (/root/colcon-bundle), Requirement.parse('colcon-bundle>=0.0.17'))
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/colcon_core/entry_point.py", line 98, in load_entry_points
    extension_type = load_entry_point(entry_point)
  File "/usr/lib/python3/dist-packages/colcon_core/entry_point.py", line 140, in load_entry_point
    return entry_point.load()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2442, in load
    self.require(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2465, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (colcon-bundle 0.0.13 (/root/colcon-bundle), Requirement.parse('colcon-bundle>=0.0.17'))
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
