### PR TITLE
Fixes ros1_sa_build.sh failing on colcon bundle

### DIFF
--- a/ws_builds/robot_ws.sh
+++ b/ws_builds/robot_ws.sh
@@ -10,4 +10,7 @@ fi
 rosdep install --from-paths src --ignore-src -r -y
 
 colcon build --build-base build --install-base install
+
+# bundle will fail without this key
+apt-key adv --fetch-keys http://packages.osrfoundation.org/gazebo.key
 colcon bundle --build-base build --install-base install --bundle-base bundle

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -11,4 +11,7 @@ rosdep update
 rosdep install --from-paths src --ignore-src -r -y
 
 colcon build --build-base build --install-base install
+
+# bundle will fail without this key
+apt-key adv --fetch-keys http://packages.osrfoundation.org/gazebo.key
 colcon bundle --build-base build --install-base install --bundle-base bundle


### PR DESCRIPTION
The following error would pop up during colcon bundle.

[9.067s] ERROR:colcon.colcon_bundle.verb:Could not fetch from
repositories: W:Skipping acquire of configured file
'main/binary-i386/Packages' as repository
'http://packages.ros.org/ros2/ubuntu bionic InRelease' doesn't support
architecture 'i386', W:GPG error:
http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic InRelease:
The following signatures couldn't be verified because the public key is
not available: NO_PUBKEY 67170598AF249743, E:The repository
'http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic
InRelease' is not signed.

The fix is to add the key for the apt server.

Testing:

Followed the manual test for sample apps in the README.md. Reproduced
the failure before making the change and confirmed that it succeeded
with kinetic/gazebo7, kinetic/gazebo9, and melodic/gazebo9.

*Issue #, if available:*

*Description of changes:*

Added lines to pull apt keys for gazebo before colcon bundle.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
