### PR TITLE
Revert -e on scripts that can / are expected to be sourced, add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ notifications:
     on_success: change
     on_failure: always
     recipients:
-      - avishaya@amazon.com
-      - avishayalon@gmail.com
+      - ros-contributions@amazon.com
+  email:
+    on_success: always
+    on_failure: always
+    recipients:
+      - travis-build@platform-notifications.robomaker.aws.a2z.com
 env:
   global:
     - GH_USER_NAME="travis-ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,105 @@
+sudo: required 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+    recipients:
+      - avishaya@amazon.com
+      - avishayalon@gmail.com
+env:
+  global:
+    - GH_USER_NAME="travis-ci"
+    - GH_USER_EMAIL="travis@travis-ci.org"
+    - AWS_DEFAULT_REGION=us-west-2
+before_install:
+- pip install --user awscli
+install:
+  # Universal steps for fetching a repository & restructuring the directory tree to align with the way our CI is set up
+  # Move travis-scripts to ros_app/.ros_ci and set TRAVIS_BUILD_DIR to be ros_app
+  - git clone -b ${CLONE_BRANCH} ${CLONE_URL} ${TRAVIS_BUILD_DIR}/../ros_app
+  - cp -R ${TRAVIS_BUILD_DIR} ${TRAVIS_BUILD_DIR}/../.ros_ci
+  - mv ${TRAVIS_BUILD_DIR}/../ros_app ${TRAVIS_BUILD_DIR}
+  - mv ${TRAVIS_BUILD_DIR}/../.ros_ci ${TRAVIS_BUILD_DIR}/ros_app/.ros_ci
+  - export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}/ros_app
+  - cd ${TRAVIS_BUILD_DIR}
+before_deploy:
+# Remove the line containing `aws s3 ls` in order to skip querying of S3
+- sed -i 's/.*aws s3 ls.*//g' .ros_ci/before_deploy.sh
+- . .ros_ci/before_deploy.sh && set +e
+jobs:
+  include:
+    - stage: Build Downstream Consumers
+      # The build jobs below are modeled after the respective .travis.yml files in the relevant repository (i.e. CLONE_URL/.travis.yml).
+      name: "Build & Bundle ROS1 Sample App"
+      env: 
+        - ROS_VERSION=1
+        - ROS_DISTRO=melodic
+        - GAZEBO_VERSION=9
+        - WORKSPACES="robot_ws simulation_ws"
+        - SA_NAME=hello-world
+        - SA_PACKAGE_NAME=hello_world_robot
+        - NO_TEST=true
+        - CLONE_URL=https://github.com/aws-robotics/aws-robomaker-sample-application-helloworld
+        - CLONE_BRANCH=ros1
+      script:
+        - . .ros_ci/add_tag.sh && set +e
+        - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+        - ".ros_ci/ce_build.sh"
+        - kill %1
+      deploy:
+        - provider: script
+          script: "echo Performing mock deploy stage"
+          on:
+            branch: master
+            
+    - name: "Build & Bundle ROS2 Sample App"
+      env: 
+        - ROS_VERSION=2 
+        - ROS_DISTRO=dashing
+        - GAZEBO_VERSION=9
+        - WORKSPACES="robot_ws simulation_ws"
+        - SA_NAME=hello-world
+        - SA_PACKAGE_NAME=hello_world_robot
+        - NO_TEST=true
+        - CLONE_URL=https://github.com/aws-robotics/aws-robomaker-sample-application-helloworld
+        - CLONE_BRANCH=ros2
+      script:
+        - . .ros_ci/add_tag.sh && set +e
+        - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+        - ".ros_ci/ce_build.sh"
+        - kill %1
+      deploy:
+        - provider: script
+          script: "echo Performing mock deploy stage"
+          on:
+            branch: master
+
+    - name: "Build ROS1 Cloud Extension"
+      env:
+        - PACKAGE_NAMES=aws_ros1_common
+        - ROS_VERSION=1
+        - ROS_DISTRO=kinetic
+        - CLONE_URL=https://github.com/aws-robotics/utils-ros1
+        - CLONE_BRANCH=master
+      script:
+        - ".ros_ci/ce_build.sh"
+      before_deploy: # Blank override - no deploy stage for CEs
+      after_deploy: # Blank override - no deploy stage for CEs
+      
+    - name: "Build ROS2 Cloud Extension"
+      env:
+        - PACKAGE_NAMES=aws_ros2_common
+        - ROS_VERSION=2
+        - ROS_DISTRO=dashing
+        - CLONE_URL="https://github.com/aws-robotics/utils-ros2" 
+        - CLONE_BRANCH=master
+      script:
+        - ".ros_ci/ce_build.sh"
+      before_deploy: # Blank override - no deploy stage for CEs
+      after_deploy: # Blank override - no deploy stage for CEs
+      
+after_deploy:
+- .ros_ci/post_deploy.sh

--- a/add_tag.sh
+++ b/add_tag.sh
@@ -36,3 +36,6 @@ else
     export SA_VERSION=${CURRENT_SA_VERSION}.${TRAVIS_BUILD_NUMBER}
     echo {\"application_version\": \"${SA_VERSION}\"} > "$TRAVIS_BUILD_DIR/version.json"
 fi
+
+# Restore default setting to be able to safely source this script in Travis: https://github.com/travis-ci/travis-ci/issues/891
+set +e

--- a/before_deploy.sh
+++ b/before_deploy.sh
@@ -14,3 +14,6 @@ cp "$TRAVIS_BUILD_DIR/version.json" "$TRAVIS_BUILD_DIR/shared/version.json"
 export S3_BUCKET_NAME=`aws s3 ls | grep "travis-source" | awk '{print $3}'`
 export SA_NAME_WITHOUT_DASHES=`echo $SA_NAME | sed -e 's/-//g'`
 export APP_MANIFEST_REPO="AppManifest-$SA_NAME-$ROS_DISTRO-gazebo$GAZEBO_VERSION"
+
+# Restore default setting to be able to safely source this script in Travis: https://github.com/travis-ci/travis-ci/issues/891
+set +e

--- a/codepipeline_deploy.sh
+++ b/codepipeline_deploy.sh
@@ -30,3 +30,6 @@ fi
 
 TIMESTAMP=`date +%s`
 aws codecommit put-file --repository-name "$APP_MANIFEST_REPO" --branch-name mainline --file-content "{\"application_version\": \"$SA_VERSION\",\"timestamp\":\"$TIMESTAMP\"}" --file-path "/version.json" --commit-message "Updating to version $SA_VERSION. Commit for this version bump: $TRAVIS_COMMIT" --name "$GH_USER_NAME" --email "$GH_USER_EMAIL" $PARENT_COMMIT_FLAG
+
+# Restore default setting to be able to safely source this script in Travis: https://github.com/travis-ci/travis-ci/issues/891
+set +e

--- a/post_deploy.sh
+++ b/post_deploy.sh
@@ -6,3 +6,6 @@ if [ ! -z "${TRAVIS_TAG}" ]; then
     echo "Skipping $0 $@"
     exit 0
 fi
+
+# Restore default setting to be able to safely source this script in Travis: https://github.com/travis-ci/travis-ci/issues/891
+set +e


### PR DESCRIPTION
Add `set -e`. Note this is not enough because the scripts could theoretically finish earlier. We should also make sure to set the default after sourcing a script: https://github.com/aws-robotics/aws-robomaker-sample-application-helloworld/pull/49

Also, this PR adds .travis.yml for testing travis-scripts against <ROS1, ROS2> x <CE, SA>.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
