### PR TITLE
Source upload override

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,26 @@
 ## Overview
 This repository contains scripts used in Travis CIs for [AWS RoboMaker] sample applications and [AWS RoboMaker] ROS Cloud Extensions.
 
+## Configuration Options
+
+Configuration is done via environment variables. When adding a new option, make sure to also pass that variable into the docker container used for the build (see `ce_build.sh`).
+
+### Common
+
+* ROS_VERSION, ROS_DISTRO, GAZEBO_VERSION: determine which build flavour and docker image to use
+
+### Sample Applications
+
+* WORKSPACES: which workspaces should be built.
+* SA_PACKAGE_NAME: controls which package's manifest file would determine the version of the application bundle that's going to be uploaded to S3.
+* UPLOAD_SOURCES: by default, the source files for ${WORKSPACES} will be uploaded (along with LICENSE, NOTICE, README and roboMakerSettings.json files). You may override the default behavior.
+  * UPLOAD_SOURCES=false: Skip source upload
+  * UPLOAD_SOURCES=<file/directory paths> to override the default sources list
+
+### Cloud Extensions
+
+* NO_TEST: unit tests are enabled by default, specify NO_TESTS=true to override.
+
 ## Testing locally
 
 ### Testing Sample Applications

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ Configuration is done via environment variables. When adding a new option, make 
 
 ### Common
 
-* ROS_VERSION, ROS_DISTRO, GAZEBO_VERSION: determine which build flavour and docker image to use
+* `ROS_VERSION`, `ROS_DISTRO`, `GAZEBO_VERSION`: determine which build flavour and docker image to use
 
 ### Sample Applications
 
-* WORKSPACES: which workspaces should be built.
-* SA_PACKAGE_NAME: controls which package's manifest file would determine the version of the application bundle that's going to be uploaded to S3.
-* UPLOAD_SOURCES: by default, the source files for ${WORKSPACES} will be uploaded (along with LICENSE, NOTICE, README and roboMakerSettings.json files). You may override the default behavior.
-  * UPLOAD_SOURCES=false: Skip source upload
-  * UPLOAD_SOURCES=<file/directory paths> to override the default sources list
+* `WORKSPACES`: which workspaces should be built.
+* `SA_PACKAGE_NAME`: controls which package's manifest file would determine the version of the application bundle that's going to be uploaded to S3.
+* `UPLOAD_SOURCES`: by default, the source files for `${WORKSPACES}` will be uploaded (along with LICENSE, NOTICE, README and roboMakerSettings.json files). You may override the default behavior.
+  * `UPLOAD_SOURCES=false`: Skip source upload
+  * `UPLOAD_SOURCES=<file/directory paths>` to override the default sources list
 
 ### Cloud Extensions
 
-* NO_TEST: unit tests are enabled by default, specify NO_TESTS=true to override.
+* `NO_TEST`: unit tests are enabled by default, specify NO_TESTS=true to override.
 
 ## Testing locally
 

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -38,6 +38,7 @@ docker run -v "${PWD}/shared:/shared" \
   -e GAZEBO_VERSION="${GAZEBO_VERSION:-7}" \
   -e DOCKER_BUILD_SCRIPT="${DOCKER_BUILD_SCRIPT}" \
   -e WORKSPACES="${WORKSPACES}" \
+  -e UPLOAD_SOURCES="${UPLOAD_SOURCES}" \
   --name "${ROS_DISTRO}-container" \
   --network=host \
   -dit "ros:${ROS_DISTRO}-ros-core" /bin/bash

--- a/common_sa_build.sh
+++ b/common_sa_build.sh
@@ -26,11 +26,21 @@ do
   fi
 done
 
-# Create archive of all sources files
-SOURCES_INCLUDES="${WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
-cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
-/usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
-tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES
+# Create archive of relevant sources files (unless UPLOAD_SOURCES is false)
+if [ ! -z "$UPLOAD_SOURCES" ] && [ "$UPLOAD_SOURCES" == "false" ]; then
+  echo "Skipping source upload for this build job"
+else
+  if [ -z "$UPLOAD_SOURCES" ]; then
+    SOURCES_INCLUDES="${WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
+    echo "Using default source upload: ${SOURCES_INCLUDES}"
+  else
+    SOURCES_INCLUDES=${UPLOAD_SOURCES}
+    echo "Override set for source upload: ${SOURCES_INCLUDES}"
+  fi
+  cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
+  /usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
+  tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES
+fi
 
 for WS in $WORKSPACES
 do


### PR DESCRIPTION
In order to properly support split workspace jobs we need to be able to decouple the workspaces used for the build from the workspaces used for source upload. 

Right now, one of robot_ws, simulation_ws would finish last and will upload a sources.zip file with only its own sources. We need sources.zip to contain all relevant code. 

The solution that I came up with is add support for overriding the default source upload behavior (usage example: https://github.com/aws-robotics/aws-robomaker-sample-application-helloworld/pull/51). 

Also added some README documentation, let me know if the wording is not clear enough.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
