### PR TITLE
Fix Code Coverage Report for ROS2 Python Packages

### DIFF
--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -35,7 +35,7 @@ if [ -z "${NO_TEST}" ]; then
     fi
     
     set +e
-    colcon test
+    colcon test --pytest-args --cov=. --cov-report=xml
     set -e
     colcon test-result --all --verbose
 
@@ -50,8 +50,7 @@ if [ -z "${NO_TEST}" ]; then
             ;;
         "python")
             # this doesn't actually support multiple packages
-            pytest --cov=src/${REPO_NAME}/${PACKAGE_NAMES} --cov-report=xml
-            cp coverage.xml /shared/coverage.info
+            cp src/${REPO_NAME}/${PACKAGE_NAMES}/coverage.xml /shared/coverage.info
             ;;
     esac
 fi


### PR DESCRIPTION
*Description of changes:*

The code coverage report for ROS2 Python packages are incorrectly missing a lot of coverage, because they have been reporting against the wrong copy of `.py` files in a workspace (copies exist under `src/`, `build/`, and `install/`...).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.