### PR TITLE
Add support for not building some worksapces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Configuration is done via environment variables. When adding a new option, make 
 ### Sample Applications
 
 * `WORKSPACES`: which workspaces should be built.
+* `SOURCE_ONLY_WORKSPACES`: workspaces which shouldn't be be built, but the source files will be included in the source upload
 * `SA_PACKAGE_NAME`: controls which package's manifest file would determine the version of the application bundle that's going to be uploaded to S3.
 * `UPLOAD_SOURCES`: by default, the source files for `${WORKSPACES}` will be uploaded (along with LICENSE, NOTICE, README and roboMakerSettings.json files). You may override the default behavior.
   * `UPLOAD_SOURCES=false`: Skip source upload

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -38,6 +38,7 @@ docker run -v "${PWD}/shared:/shared" \
   -e GAZEBO_VERSION="${GAZEBO_VERSION:-7}" \
   -e DOCKER_BUILD_SCRIPT="${DOCKER_BUILD_SCRIPT}" \
   -e WORKSPACES="${WORKSPACES}" \
+  -e SOURCE_ONLY_WORKSPACES="${SOURCE_ONLY_WORKSPACES}" \
   -e UPLOAD_SOURCES="${UPLOAD_SOURCES}" \
   --name "${ROS_DISTRO}-container" \
   --network=host \

--- a/common_sa_build.sh
+++ b/common_sa_build.sh
@@ -15,8 +15,10 @@ if [ -z "$WORKSPACES" ]; then
   WORKSPACES="robot_ws simulation_ws"
 fi
 
+SOURCE_WORKSPACES="${WORKSPACES} ${SOURCE_ONLY_WORKSPACES}"
+
 # Run ROSWS update in each workspace before creating archive
-for WS in $WORKSPACES
+for WS in $SOURCE_WORKSPACES
 do
   WS_DIR="/${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/${WS}"
   echo "looking for ${WS}, $WS_DIR"
@@ -30,7 +32,7 @@ done
 if [ ! -z "$UPLOAD_SOURCES" ] && [ "$UPLOAD_SOURCES" == "false" ]; then
   echo "Skipping source upload for this build job"
 else
-  SOURCES_INCLUDES="${WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
+  SOURCES_INCLUDES="${SOURCE_WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
   cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
   /usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
   tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES


### PR DESCRIPTION
*Issue #, if available:*
This change is to support the issue that robot_ws doesn't appear in the RoboMaker Cloud9 IDE console for ObjectTracker.
*Description of changes:*
Adds an optional argument for source only workspaces that won't be built but will be included in the sources.zip

*Testing*
(output from testing can be seen at the end of the build logs)

Works with WORKSPACES and SOURCE_ONLY_WORKSPACES specified (ObjectTracker):
https://travis-ci.com/ryanewel/aws-robomaker-sample-application-objecttracker/builds/140542156
Only the simulation ws was built and bundled but both the robot_ws and the simulation_ws are included in the zip

Works with default
https://travis-ci.com/ryanewel/aws-robomaker-sample-application-helloworld/builds/140541934
The robot_ws and simulation_ws bundles were created and robot_ws and simulation_ws are in the zip

Work with just WORKSPACES (simulation_ws)
https://travis-ci.com/ryanewel/aws-robomaker-sample-application-deepracer/builds/140542212
Only simulation_ws is built/bundled and only simulation_ws is in the sources.zip

**Changes required in Object Tracker**
Add 
SOURCE_ONLY_WORKSPACES="robot_ws"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
