### PR TITLE
Build cloud extensions and sample apps as non-root user

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -16,10 +16,10 @@ cp -r "${SCRIPT_DIR}" shared/
 if [ -z "${SA_NAME}" ];
 then
   # SA_NAME not set - assume a Cloud Extension build
-  BUILD_SCRIPT_NAME=ros"$ROS_VERSION"_build.sh
+  BUILD_SCRIPT_NAME=ros"${ROS_VERSION}"_build.sh
 else
   # SA_NAME is set - assume a Sample Application build
-  BUILD_SCRIPT_NAME=ros"$ROS_VERSION"_sa_build.sh
+  BUILD_SCRIPT_NAME=ros"${ROS_VERSION}"_sa_build.sh
 fi
 
 echo "using Build script, ${BUILD_SCRIPT_NAME}"

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -43,13 +43,21 @@ docker run -v "${PWD}/shared:/shared" \
   --name "${ROS_DISTRO}-container" \
   --network=host \
   -dit "ros:${ROS_DISTRO}-ros-core" /bin/bash
+
+# add the rosdev non-root user
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'groupadd -g 999 rosdev && useradd -m -u 999 -g rosdev -G sudo rosdev'
+# set the rosdev user password to rosdev
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'echo "rosdev:rosdev" | chpasswd'
+# allow rosdev to use sudo without password
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'echo "rosdev ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers'
 # make a workspace in the docker container
-docker exec "${ROS_DISTRO}-container" /bin/bash -c 'mkdir -p "/${ROS_DISTRO}_ws/src"'
+docker exec --user rosdev "${ROS_DISTRO}-container" /bin/bash -c 'sudo mkdir -p "/${ROS_DISTRO}_ws/src"'
 # copy the code over to the docker container
 docker cp "${TRAVIS_BUILD_DIR}" "${ROS_DISTRO}-container":"/${ROS_DISTRO}_ws/src/"
+docker exec --user rosdev "${ROS_DISTRO}-container" /bin/bash -c 'sudo chown -R rosdev "/${ROS_DISTRO}_ws"'
 # execute build scripts and run test
+docker exec --user rosdev "${ROS_DISTRO}"-container /bin/bash "${DOCKER_BUILD_SCRIPT}"
 
-docker exec "${ROS_DISTRO}"-container /bin/bash "${DOCKER_BUILD_SCRIPT}"
 # upload coverage report to codecov
 if [ -z "${NO_TEST}" ];
 then

--- a/common_sa_build.sh
+++ b/common_sa_build.sh
@@ -7,21 +7,21 @@ export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 sudo rm -rf /etc/ros/rosdep/sources.list.d/*
 sudo rosdep init && rosdep update
 
-. /opt/ros/$ROS_DISTRO/setup.sh
+. /opt/ros/${ROS_DISTRO}/setup.sh
 
 BUILD_DIR_NAME=`basename ${TRAVIS_BUILD_DIR}`
 
-if [ -z "$WORKSPACES" ]; then
+if [ -z "${WORKSPACES}" ]; then
   WORKSPACES="robot_ws simulation_ws"
 fi
 
 SOURCE_WORKSPACES="${WORKSPACES} ${SOURCE_ONLY_WORKSPACES}"
 
 # Run ROSWS update in each workspace before creating archive
-for WS in $SOURCE_WORKSPACES
+for WS in ${SOURCE_WORKSPACES}
 do
   WS_DIR="/${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/${WS}"
-  echo "looking for ${WS}, $WS_DIR"
+  echo "looking for ${WS}, ${WS_DIR}"
   if [ -d "${WS_DIR}" ]; then
     echo "WS ${WS_DIR} found, running rosws update"
     rosws update -t "${WS_DIR}"
@@ -29,16 +29,16 @@ do
 done
 
 # Create archive of relevant source files (unless UPLOAD_SOURCES is false)
-if [ ! -z "$UPLOAD_SOURCES" ] && [ "$UPLOAD_SOURCES" == "false" ]; then
+if [ ! -z "${UPLOAD_SOURCES}" ] && [ "${UPLOAD_SOURCES}" == "false" ]; then
   echo "Skipping source upload for this build job"
 else
   SOURCES_INCLUDES="${SOURCE_WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
   cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
-  sudo /usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
-  sudo tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES
+  sudo /usr/bin/zip -r /shared/sources.zip ${SOURCES_INCLUDES}
+  sudo tar cvzf /shared/sources.tar.gz ${SOURCES_INCLUDES}
 fi
 
-for WS in $WORKSPACES
+for WS in ${WORKSPACES}
 do
   # use colcon as build tool to build the workspace if it exists
   WS_DIR="/${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/${WS}"

--- a/common_sa_build.sh
+++ b/common_sa_build.sh
@@ -4,12 +4,12 @@ set -xe
 export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 
 # Remove the old rosdep sources.list
-rm -rf /etc/ros/rosdep/sources.list.d/*
-rosdep init && rosdep update
+sudo rm -rf /etc/ros/rosdep/sources.list.d/*
+sudo rosdep init && rosdep update
 
 . /opt/ros/$ROS_DISTRO/setup.sh
 
-BUILD_DIR_NAME=`basename $TRAVIS_BUILD_DIR`
+BUILD_DIR_NAME=`basename ${TRAVIS_BUILD_DIR}`
 
 if [ -z "$WORKSPACES" ]; then
   WORKSPACES="robot_ws simulation_ws"
@@ -34,8 +34,8 @@ if [ ! -z "$UPLOAD_SOURCES" ] && [ "$UPLOAD_SOURCES" == "false" ]; then
 else
   SOURCES_INCLUDES="${SOURCE_WORKSPACES} LICENSE* NOTICE* README* roboMakerSettings.json"
   cd /${ROS_DISTRO}_ws/src/${BUILD_DIR_NAME}/
-  /usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
-  tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES
+  sudo /usr/bin/zip -r /shared/sources.zip $SOURCES_INCLUDES
+  sudo tar cvzf /shared/sources.tar.gz $SOURCES_INCLUDES
 fi
 
 for WS in $WORKSPACES
@@ -46,7 +46,7 @@ do
   if [ -f "${WS_BUILD_SCRIPT}" ]; then
     cd "${WS_DIR}"
     bash "${WS_BUILD_SCRIPT}"
-    mv ./bundle/output.tar /shared/"${WS}".tar
+    sudo mv ./bundle/output.tar /shared/"${WS}".tar
   else
     echo "Unable to find build script ${WS_BUILD_SCRIPT}, build failed"
     exit 1

--- a/gazebo/dashing-gazebo9/post_rosdep_install.sh
+++ b/gazebo/dashing-gazebo9/post_rosdep_install.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-
-# Only set up Gazebo's repository
 set -e
 
+# Only set up Gazebo's repository
 echo "Setting up Gazebo repository"
 
-apt-get install wget -y
-echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
-apt-get update
+sudo apt-get install -y wget
+echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list
+wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo apt-get update

--- a/gazebo/kinetic-gazebo9/post_rosdep_install.sh
+++ b/gazebo/kinetic-gazebo9/post_rosdep_install.sh
@@ -1,35 +1,34 @@
 #!/bin/bash
-
-# Remove Kinetic Gazebo 7 and Install Kinetic Gazebo 9
 set -e
 
+# Remove Kinetic Gazebo 7 and Install Kinetic Gazebo 9
 echo "Setting up Gazebo 9"
 
-apt-get install wget -y
-echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
-apt-get update
+sudo apt-get install -y wget
+echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list
+wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo apt-get update
 
 G9_APT_FILE="/etc/ros/rosdep/sources.list.d/00-gazebo9.list"
-rm -f "${G9_APT_FILE}"
-touch "${G9_APT_FILE}"
-echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/gazebo.yaml" >> "${G9_APT_FILE}"
-echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/indigo.yaml indigo" >> "${G9_APT_FILE}"
-echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/jade.yaml jade" >> "${G9_APT_FILE}"
-echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/kinetic.yaml kinetic" >> "${G9_APT_FILE}"
-echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/lunar.yaml lunar" >> "${G9_APT_FILE}"
+sudo rm -f "${G9_APT_FILE}"
+sudo touch "${G9_APT_FILE}"
+echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/gazebo.yaml" | sudo tee -a "${G9_APT_FILE}"
+echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/indigo.yaml indigo" | sudo tee -a "${G9_APT_FILE}"
+echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/jade.yaml jade" | sudo tee -a "${G9_APT_FILE}"
+echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/kinetic.yaml kinetic" | sudo tee -a "${G9_APT_FILE}"
+echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/lunar.yaml lunar" | sudo tee -a "${G9_APT_FILE}"
 
-apt-get update
+sudo apt-get update
 
 echo "Uninstalling Gazebo 7"
-apt-get remove --purge *gazebo7* -y
-apt-get remove ros-kinetic-gazebo* -y
-apt-get remove libgazebo* -y
-apt-get remove gazebo* -y
+sudo apt-get remove --purge -y *gazebo7*
+sudo apt-get remove -y ros-kinetic-gazebo*
+sudo apt-get remove -y libgazebo*
+sudo apt-get remove -y gazebo*
 echo "Gazebo 7 uninstalled with success"
 
 echo "Installing Gazebo 9"
-apt-get install ros-kinetic-gazebo9-* -y
+sudo apt-get install -y ros-kinetic-gazebo9-*
 echo "Gazebo 9 installed with success"
 
 echo "Gazebo 9 setup completed with success"

--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -2,18 +2,19 @@
 set -xe
 
 # install dependencies
-apt update && apt install -y lcov python3-pip python-rosinstall libgtest-dev cmake && rosdep update
-apt update && apt install -y python3-colcon-common-extensions && pip3 install -U setuptools
+sudo apt-get update && sudo apt-get install -y lcov python3-pip python-rosinstall libgtest-dev cmake && rosdep update
+sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions && sudo -H pip3 install -U setuptools
 # nosetests needs coverage for Python 2
-apt-get install python-pip -y && pip install -U coverage
+sudo apt-get install python-pip -y && sudo -H pip install -U coverage
 # enable Python coverage "https://github.com/ros/catkin/blob/kinetic-devel/cmake/test/nosetests.cmake#L59"
 export CATKIN_TEST_COVERAGE=1
 
 REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})
 echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"
 
+. "/opt/ros/${ROS_DISTRO}/setup.sh"
+
 cd "/${ROS_DISTRO}_ws/"
-# use colcon as build tool to build the package, and optionally build tests
 if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
     mkdir dep
     cd "/${ROS_DISTRO}_ws/dep"
@@ -25,16 +26,15 @@ else
     rosdep install --from-paths src --ignore-src --rosdistro "${ROS_DISTRO}" -r -y
 fi
 
-. "/opt/ros/${ROS_DISTRO}/setup.sh"
-
+# use colcon as build tool to build the package, and optionally build tests
 colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'
 
+# build and run unit tests
 if [ -z "${NO_TEST}" ]; then
     if [ ! -z "${PACKAGE_NAMES}" ]; then
         colcon build --packages-select ${PACKAGE_NAMES} --cmake-target tests
     fi
 
-    # run unit tests
     . ./install/setup.sh
 
     if [ "${TRAVIS_BRANCH}" == "master" ] && [ -d "./dep" ]; then
@@ -53,13 +53,13 @@ if [ -z "${NO_TEST}" ]; then
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             lcov --list coverage.info
             cd "/${ROS_DISTRO}_ws/"
-            mv coverage.info /shared
+            sudo cp coverage.info /shared/
             ;;
         "python")
             # this doesn't actually support multiple packages
             cd "/${ROS_DISTRO}_ws/build/${PACKAGE_NAMES}"
             coverage xml
-            cp coverage.xml /shared/coverage.info
+            sudo cp coverage.xml /shared/coverage.info
             ;;
     esac
 fi

--- a/ros1_sa_build.sh
+++ b/ros1_sa_build.sh
@@ -6,8 +6,8 @@ export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 # install dependencies
 ROS_BOOTSTRAP_SCRIPT=${SCRIPT_DIR}/ros_bootstrap.sh
 "${ROS_BOOTSTRAP_SCRIPT}"
-apt-get update && apt-get install --no-install-recommends -y python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
-pip3 install colcon-bundle colcon-ros-bundle
+sudo apt-get update && sudo apt-get install --no-install-recommends -y python3-colcon-common-extensions ros-${ROS_DISTRO}-ros-base
+sudo -H pip3 install -U colcon-bundle colcon-ros-bundle
 
 COMMON_SA_BUILD_SCRIPT=${SCRIPT_DIR}/common_sa_build.sh
 . "${COMMON_SA_BUILD_SCRIPT}"

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -6,7 +6,7 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F
 echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 apt update && apt install -y python3 python3-pip lcov cmake && rosdep update
 apt update && apt install -y python3-rosinstall python3-colcon-common-extensions && pip3 install -U setuptools coverage pytest
-apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep $ROS_DISTRO | xargs apt install -y
+apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep ${ROS_DISTRO} | xargs apt install -y
 
 REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})
 echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -6,21 +6,21 @@ export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 # install dependencies
 ROS_BOOTSTRAP_SCRIPT=${SCRIPT_DIR}/ros_bootstrap.sh
 "${ROS_BOOTSTRAP_SCRIPT}"
-apt-get update && apt-get install --no-install-recommends -y python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
-apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep $ROS_DISTRO | xargs apt install -y
-pip3 install colcon-bundle colcon-ros-bundle
+sudo apt-get update && sudo apt-get install --no-install-recommends -y python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
+apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep $ROS_DISTRO | xargs sudo apt-get install -y
+sudo -H pip3 install -U colcon-bundle colcon-ros-bundle
 
 # Get latest colcon bundle
 COLCON_BUNDLE_INSTALL_PATH="${HOME}/colcon-bundle"
-rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
+sudo rm -rf "${COLCON_BUNDLE_INSTALL_PATH}"
 COLCON_ROS_BUNDLE_INSTALL_PATH="${HOME}/colcon-ros-bundle"
-rm -rf "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
+sudo rm -rf "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
 git clone https://github.com/colcon/colcon-bundle "${COLCON_BUNDLE_INSTALL_PATH}"
 git clone https://github.com/colcon/colcon-ros-bundle "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
 
-pip3 install --upgrade pip
-pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
-pip install -U --editable "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
+sudo -H pip3 install -U pip
+sudo -H pip install -U --editable "${COLCON_BUNDLE_INSTALL_PATH}"
+sudo -H pip install -U --editable "${COLCON_ROS_BUNDLE_INSTALL_PATH}"
 
 COMMON_SA_BUILD_SCRIPT=${SCRIPT_DIR}/common_sa_build.sh
 . "${COMMON_SA_BUILD_SCRIPT}"

--- a/ros2_sa_build.sh
+++ b/ros2_sa_build.sh
@@ -6,8 +6,8 @@ export SCRIPT_DIR=$(dirname ${DOCKER_BUILD_SCRIPT})
 # install dependencies
 ROS_BOOTSTRAP_SCRIPT=${SCRIPT_DIR}/ros_bootstrap.sh
 "${ROS_BOOTSTRAP_SCRIPT}"
-sudo apt-get update && sudo apt-get install --no-install-recommends -y python3-colcon-common-extensions ros-$ROS_DISTRO-ros-base
-apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep $ROS_DISTRO | xargs sudo apt-get install -y
+sudo apt-get update && sudo apt-get install --no-install-recommends -y python3-colcon-common-extensions ros-${ROS_DISTRO}-ros-base
+apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep ${ROS_DISTRO} | xargs sudo apt-get install -y
 sudo -H pip3 install -U colcon-bundle colcon-ros-bundle
 
 # Get latest colcon bundle

--- a/ros_bootstrap.sh
+++ b/ros_bootstrap.sh
@@ -6,12 +6,12 @@ sudo apt-get update && sudo apt-get install -q -y dirmngr curl gnupg2 lsb-releas
 sudo -H pip3 install -U setuptools
 
 if [ "${ROS_VERSION}" == "1" ]; then
-  sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+  echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
   apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   sudo apt-get update && sudo apt-get install -y python-rosdep python-rosinstall
 elif [ "${ROS_VERSION}" == "2" ]; then
   curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-  sudo sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+  echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2-latest.list
   sudo apt-get update && sudo apt-get install -y python3-rosdep python3-rosinstall
 else
   echo "ROS_VERSION not defined or recognized"

--- a/ros_bootstrap.sh
+++ b/ros_bootstrap.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-# Set up ROS APT and install basic dependencies (rosdep, rosinstall). Must have ROS_VERSION set when called.
 set -xe
 
-apt-get update && apt-get install -q -y dirmngr curl gnupg2 lsb-release zip python3-pip python3-apt dpkg
-pip3 install -U setuptools
+# Set up ROS APT and install basic dependencies (rosdep, rosinstall). Must have ROS_VERSION set when called.
+sudo apt-get update && sudo apt-get install -q -y dirmngr curl gnupg2 lsb-release zip python3-pip python3-apt dpkg
+sudo -H pip3 install -U setuptools
 
 if [ "${ROS_VERSION}" == "1" ]; then
-  sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+  sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
   apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-  apt-get update && apt-get install -y python-rosdep python-rosinstall
+  sudo apt-get update && sudo apt-get install -y python-rosdep python-rosinstall
 elif [ "${ROS_VERSION}" == "2" ]; then
-  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
-  sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
-  apt-get update && apt-get install -y python3-rosdep python3-rosinstall
+  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+  sudo sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+  sudo apt-get update && sudo apt-get install -y python3-rosdep python3-rosinstall
 else
   echo "ROS_VERSION not defined or recognized"
   exit 1

--- a/ws_builds/robot_ws.sh
+++ b/ws_builds/robot_ws.sh
@@ -12,5 +12,5 @@ rosdep install --from-paths src --ignore-src -r -y
 colcon build --build-base build --install-base install
 
 # bundle will fail without this key
-apt-key adv --fetch-keys http://packages.osrfoundation.org/gazebo.key
+sudo apt-key adv --fetch-keys http://packages.osrfoundation.org/gazebo.key
 colcon bundle --build-base build --install-base install --bundle-base bundle

--- a/ws_builds/simulation_ws.sh
+++ b/ws_builds/simulation_ws.sh
@@ -13,5 +13,5 @@ rosdep install --from-paths src --ignore-src -r -y
 colcon build --build-base build --install-base install
 
 # bundle will fail without this key
-apt-key adv --fetch-keys http://packages.osrfoundation.org/gazebo.key
+sudo apt-key adv --fetch-keys http://packages.osrfoundation.org/gazebo.key
 colcon bundle --build-base build --install-base install --bundle-base bundle


### PR DESCRIPTION
*Description of changes:*

Update the build scripts so that the builds are performed as a non-root user in the Docker containers.

Test results thus far:
- https://github.com/aws-robotics/travis-scripts/runs/363529890
- https://github.com/aws-robotics/cloudwatch-common/pull/47
- https://github.com/aws-robotics/aws-robomaker-sample-application-objecttracker/pull/75
- https://github.com/aws-robotics/aws-robomaker-sample-application-objecttracker/pull/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.