### PR TITLE
Fix dependency fetching of ROS2 CEs

### DIFF
--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -15,7 +15,7 @@ echo "repo: ${REPO_NAME} branch: ${TRAVIS_BRANCH}"
 . "/opt/ros/${ROS_DISTRO}/setup.sh"
 
 cd "/${ROS_DISTRO}_ws/"
-if [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
+if [ "${TRAVIS_BRANCH}" == "master" ] && [ -f "./src/${REPO_NAME}/.rosinstall.master" ]; then
     mkdir dep
     cd "/${ROS_DISTRO}_ws/dep"
     ln -s "../src/${REPO_NAME}/.rosinstall.master" .rosinstall


### PR DESCRIPTION
This is the reason for failures in the release-latest branch (e.g. https://travis-ci.org/github/aws-robotics/cloudwatchmetrics-ros2/builds/667953816). We're always using rosinstall intead of using it only on master like in [ros1](https://github.com/aws-robotics/travis-scripts/blob/master/ros1_build.sh#L18). Likely a leftover from before the ROS2 launch where the CEs were not available in apt yet so we had to use rosinstall for all cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
