### PR TITLE
Migrate to using rostooling/setup-ros-docker images

### DIFF
--- a/ce_build.sh
+++ b/ce_build.sh
@@ -52,12 +52,12 @@ docker run -v "${PWD}/shared:/shared" \
   -dit "${DOCKER_IMAGE_NAME}" /bin/bash
 
 # make a workspace in the docker container
-docker exec "${ROS_DISTRO}-container" /bin/bash -c 'mkdir -p "/${ROS_DISTRO}_ws/src"'
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'sudo mkdir -p "/${ROS_DISTRO}_ws/src"'
 # copy the code over to the docker container
 docker cp "${TRAVIS_BUILD_DIR}" "${ROS_DISTRO}-container":"/${ROS_DISTRO}_ws/src/"
-docker exec --user rosbuild "${ROS_DISTRO}-container" /bin/bash -c 'sudo chown -R rosbuild "/${ROS_DISTRO}_ws"'
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'sudo chown -R rosbuild "/${ROS_DISTRO}_ws"'
 # execute build scripts and run test
-docker exec --user rosbuild "${ROS_DISTRO}"-container /bin/bash "${DOCKER_BUILD_SCRIPT}"
+docker exec "${ROS_DISTRO}"-container /bin/bash "${DOCKER_BUILD_SCRIPT}"
 
 # upload coverage report to codecov
 if [ -z "${NO_TEST}" ];

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -26,10 +26,13 @@ then
   fi
 fi
 
+[ ${ROS_DISTRO} == "kinetic" ] && UBUNTU_DISTRO=xenial || UBUNTU_DISTRO=bionic
+DOCKER_IMAGE_NAME="rostooling/setup-ros-docker:ubuntu-${UBUNTU_DISTRO}-ros-${ROS_DISTRO}-ros-base-latest"
+
 echo "using Build script, ${BUILD_SCRIPT_NAME}"
 DOCKER_BUILD_SCRIPT="/shared/$(basename -- ${SCRIPT_DIR})/${BUILD_SCRIPT_NAME}"
 # get a docker container from OSRF's docker hub
-docker pull "ros:${ROS_DISTRO}-ros-core"
+docker pull "${DOCKER_IMAGE_NAME}"
 # run docker container
 docker run -v "${PWD}/shared:/shared" \
   -e ROS_DISTRO="${ROS_DISTRO}" \
@@ -46,7 +49,7 @@ docker run -v "${PWD}/shared:/shared" \
   -e UPLOAD_SOURCES="${UPLOAD_SOURCES}" \
   --name "${ROS_DISTRO}-container" \
   --network=host \
-  -dit "ros:${ROS_DISTRO}-ros-core" /bin/bash
+  -dit "${DOCKER_IMAGE_NAME}" /bin/bash
 
 # add the rosdev non-root user
 docker exec "${ROS_DISTRO}-container" /bin/bash -c 'groupadd -g 999 rosdev && useradd -m -u 999 -g rosdev -G sudo rosdev'

--- a/ce_build.sh
+++ b/ce_build.sh
@@ -51,19 +51,13 @@ docker run -v "${PWD}/shared:/shared" \
   --network=host \
   -dit "${DOCKER_IMAGE_NAME}" /bin/bash
 
-# add the rosdev non-root user
-docker exec "${ROS_DISTRO}-container" /bin/bash -c 'groupadd -g 999 rosdev && useradd -m -u 999 -g rosdev -G sudo rosdev'
-# set the rosdev user password to rosdev
-docker exec "${ROS_DISTRO}-container" /bin/bash -c 'echo "rosdev:rosdev" | chpasswd'
-# allow rosdev to use sudo without password
-docker exec "${ROS_DISTRO}-container" /bin/bash -c 'echo "rosdev ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers'
 # make a workspace in the docker container
-docker exec --user rosdev "${ROS_DISTRO}-container" /bin/bash -c 'sudo mkdir -p "/${ROS_DISTRO}_ws/src"'
+docker exec "${ROS_DISTRO}-container" /bin/bash -c 'mkdir -p "/${ROS_DISTRO}_ws/src"'
 # copy the code over to the docker container
 docker cp "${TRAVIS_BUILD_DIR}" "${ROS_DISTRO}-container":"/${ROS_DISTRO}_ws/src/"
-docker exec --user rosdev "${ROS_DISTRO}-container" /bin/bash -c 'sudo chown -R rosdev "/${ROS_DISTRO}_ws"'
+docker exec --user rosbuild "${ROS_DISTRO}-container" /bin/bash -c 'sudo chown -R rosbuild "/${ROS_DISTRO}_ws"'
 # execute build scripts and run test
-docker exec --user rosdev "${ROS_DISTRO}"-container /bin/bash "${DOCKER_BUILD_SCRIPT}"
+docker exec --user rosbuild "${ROS_DISTRO}"-container /bin/bash "${DOCKER_BUILD_SCRIPT}"
 
 # upload coverage report to codecov
 if [ -z "${NO_TEST}" ];


### PR DESCRIPTION
*Description of changes:*

With [the recent changes to the ROS Docker images](https://discourse.ros.org/t/announcement-trimmed-ros-gazebo-docker-images-released/14342), the [rostooling/setup-ros-docker Docker images](https://hub.docker.com/r/rostooling/setup-ros-docker) would be more appropriate to use for building ROS packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
