### PR TITLE
Blacklisting setuptools v50.0.0

### DIFF
--- a/ros1_build.sh
+++ b/ros1_build.sh
@@ -3,7 +3,7 @@ set -xe
 
 # install dependencies
 sudo apt-get update && sudo apt-get install -y lcov python3-pip python-rosinstall libgtest-dev cmake && rosdep update
-sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions && sudo -H pip3 install -U setuptools
+sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions && sudo -H pip3 install -U setuptools!=50.0.0
 # nosetests needs coverage for Python 2
 sudo apt-get install python-pip -y && sudo -H pip install -U coverage
 # enable Python coverage "https://github.com/ros/catkin/blob/kinetic-devel/cmake/test/nosetests.cmake#L59"

--- a/ros2_build.sh
+++ b/ros2_build.sh
@@ -3,7 +3,7 @@ set -xe
 
 # install dependencies
 sudo apt-get update && sudo apt-get install -y python3 python3-pip lcov cmake && rosdep update
-sudo apt-get update && sudo apt-get install -y python3-rosinstall python3-colcon-common-extensions && sudo -H pip3 install -U setuptools coverage pytest
+sudo apt-get update && sudo apt-get install -y python3-rosinstall python3-colcon-common-extensions && sudo -H pip3 install -U setuptools!=50.0.0 coverage pytest
 apt list --upgradable 2>/dev/null | awk {'print $1'} | sed 's/\/.*//g' | grep ${ROS_DISTRO} | xargs sudo apt-get install -y
 
 REPO_NAME=$(basename -- ${TRAVIS_BUILD_DIR})

--- a/ros_bootstrap.sh
+++ b/ros_bootstrap.sh
@@ -3,7 +3,7 @@ set -xe
 
 # Set up ROS APT and install basic dependencies (rosdep, rosinstall). Must have ROS_VERSION set when called.
 sudo apt-get update && sudo apt-get install -q -y dirmngr curl gnupg2 lsb-release zip python3-pip python3-apt dpkg
-sudo -H pip3 install -U setuptools
+sudo -H pip3 install -U setuptools!=50.0.0
 
 if [ "${ROS_VERSION}" == "1" ]; then
   echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros-latest.list


### PR DESCRIPTION
*Issue #, if available:*
[Broken setuptools v50.0.0](https://github.com/pypa/setuptools/issues/2356) is causing our sample apps CI builds to fail.

*Description of changes:*
This change blacklists setuptools v50.0.0 during environment setup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
